### PR TITLE
Allow passing CPPFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ TARGET=nodau
 VERSION=0.3rc6
 
 NODAU_CFLAGS ?= -Wall -g -pedantic -DTARGET=\"$(TARGET)\" -DVERSION=\"$(VERSION)\" $(CFLAGS)
+NODAU_CPPFLAGS ?= $(CPPFLAGS)
 NODAU_CLIBS ?= -lsqlite3 -lncurses -lcrypto $(CLIBS)
 NODAU_LDFLAGS ?= $(LDFLAGS)
 
@@ -54,6 +55,6 @@ uninstall:
 fresh: clean all
 
 $(SRCDIR)/%.o: $(SRCDIR)/%.c
-	$(CC) $(NODAU_CFLAGS) -o $@ -c $<
+	$(CC) $(NODAU_CPPFLAGS) $(NODAU_CFLAGS) -o $@ -c $<
 
 .PHONY: all default distclean dist dist-base dist-bz2 dist-gz clean fresh install uninstall


### PR DESCRIPTION
This allows passing FORTIFY_SOURCE hardening setting for the build.

Note: During build with following additional flags set

```
CFLAGS=-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security
CPPFLAGS=-D_FORTIFY_SOURCE=2
LDFLAGS=-Wl,-z,relro
```

the build shows up some more warnings:

```
cc -D_FORTIFY_SOURCE=2 -Wall -g -pedantic -DTARGET=\"nodau\" -DVERSION=\"0.3rc6\" -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -o src/nodau.o -c src/nodau.c
cc -D_FORTIFY_SOURCE=2 -Wall -g -pedantic -DTARGET=\"nodau\" -DVERSION=\"0.3rc6\" -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -o src/db.o -c src/db.c
src/db.c: In function ‘db_decrypt’:
src/db.c:521:9: warning: variable ‘name’ set but not used [-Wunused-but-set-variable]
src/db.c:520:9: warning: variable ‘date’ set but not used [-Wunused-but-set-variable]
src/db.c: In function ‘db_connect’:
src/db.c:153:11: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
src/db.c:155:11: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
src/db.c:160:10: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
src/db.c:183:11: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
cc -D_FORTIFY_SOURCE=2 -Wall -g -pedantic -DTARGET=\"nodau\" -DVERSION=\"0.3rc6\" -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -o src/lib.o -c src/lib.c
src/lib.c: In function ‘create_datemask’:
src/lib.c:42:10: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
cc -D_FORTIFY_SOURCE=2 -Wall -g -pedantic -DTARGET=\"nodau\" -DVERSION=\"0.3rc6\" -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -o src/edit.o -c src/edit.c
src/edit.c: In function ‘edit’:
src/edit.c:251:12: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
src/edit.c: In function ‘edit_ext’:
src/edit.c:177:10: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
src/edit.c: In function ‘edit_builtin’:
src/edit.c:128:27: warning: ‘ch’ may be used uninitialized in this function [-Wmaybe-uninitialized]
cc -D_FORTIFY_SOURCE=2 -Wall -g -pedantic -DTARGET=\"nodau\" -DVERSION=\"0.3rc6\" -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -o src/crypto.o -c src/crypto.c
cc -D_FORTIFY_SOURCE=2 -Wall -g -pedantic -DTARGET=\"nodau\" -DVERSION=\"0.3rc6\" -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -o src/config.o -c src/config.c
src/config.c: In function ‘config_file’:
src/config.c:81:11: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
src/config.c:83:11: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
cc -Wl,-z,relro -o nodau src/nodau.o src/db.o src/lib.o src/edit.o src/crypto.o src/config.o -lsqlite3 -lncurses -lcrypto
```

Regards,
Salvatore
