### PR TITLE
Drop set but unused variables

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -517,14 +517,10 @@ void db_decrypt(char* search)
 
 	/* found the note */
 	if (result->num_rows) {
-		char* date;
-		char* name;
 		char* text;
 		char* crypt;
 
 		/* get the data */
-		date = db_gettime(result->data[COLUMN(0,COL_DATE)]);
-		name = result->data[COLUMN(0,COL_NAME)];
 		text = result->data[COLUMN(0,COL_TEXT)];
 		crypt = result->data[COLUMN(0,COL_CRYPT)];
 


### PR DESCRIPTION
During build (with -Wunused-but-set-variable) enabled, the build shows:

```
src/db.c:521:9: warning: variable ‘name’ set but not used [-Wunused-but-set-variable]
src/db.c:520:9: warning: variable ‘date’ set but not used [-Wunused-but-set-variable]
```
