### PR TITLE
Add 'append' option to help text for nodau on command line

### DIFF
--- a/src/nodau.c
+++ b/src/nodau.c
@@ -42,6 +42,7 @@ static void usage()
 		" encrypt <name>  encrypt a new or existing note\n"
 		" decrypt <name>  decrypt an encrypted note\n"
 		" edit <name>     open an existing note for editing\n"
+		" append <name>   when piping data from stdin, append to an existing note\n"
 		" show <name>     display an existing note\n"
 		" del <search>    accepts name or search term\n\n"
 		"See the nodau man page for more details.\n\n",


### PR DESCRIPTION
Hi

The new 'append' option is documented in manpage, but seems not added to also the help text on command line for nodau.

In case you think it is worth to have it also added there, you can pull from this request. Otherwise please ignore :)

Regards,
Salvatore
