### PR TITLE
Fix seg fault when listing non existing keyword

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-CHANGES:
+HANGES:
 0.1
 	- initial release
 0.2
@@ -79,3 +79,7 @@ CHANGES:
 	 <carnil <at> debian.org>)
 	- fix typo in an error message
 	- a bunch of small fixes to remove some compiler warnings
+0.3.9
+	- Fix segfault when running 'nodau list' with search keyword,
+	  and there are no matches (by Omer Dagan 
+	  <mr.omer.dagan <at> gmail.com>)

--- a/src/db.c
+++ b/src/db.c
@@ -298,7 +298,6 @@ int db_list(char* search)
 		/* if there's nothing then try a time search */
 		if (res->num_rows == 0) {
 			unsigned int idate;
-			db_result_free(res);
 			/* at time */
 			if (strncmp(search,"t@",2) == 0) {
 				idate = db_getstamp(search+2);
@@ -316,6 +315,7 @@ int db_list(char* search)
 		/* nothing there */
 		if (!res || !res->num_rows || !res->num_cols) {
 			printf("No notes match '%s'\n",search);
+			db_result_free(res);
 			return 0;
 		}
 	}


### PR DESCRIPTION
Before fix- When running 'nodau list' with search keyword, and there is no match there is a seg fault.
It happens because `db_result_free(res)` is called before this check: `if (!res || !res->num_rows || !res->num_cols)`, then the check causes seg fault because res contains garbage